### PR TITLE
docs: FastAPI統合・Flask廃止に伴うセットアップガイドと起動スクリプトドキュメントの更新

### DIFF
--- a/doc/how-to/TSK-HT-001_プロセス起動スクリプト説明.md
+++ b/doc/how-to/TSK-HT-001_プロセス起動スクリプト説明.md
@@ -1,47 +1,41 @@
-# プロセス起動スクリプト (`.bat`ファイル) の説明
+# プロセス起動スクリプト (`scripts/*.bat`) の説明
 
-このドキュメントでは、プロジェクトで使用される主要な`.bat`ファイルについて説明します。これらのスクリプトは、アプリケーションの異なるコンポーネントを起動するために使用されます。
+このドキュメントでは、プロジェクトで使用される `scripts/` ディレクトリ配下の主要な `.bat` ファイルについて説明します。
+WebGUI は FastAPI アプリケーション (`src/main.py`) へ統合されたため、1つのプロセス起動でスケジューラバックエンドと WebGUI の両方が起動します。
 
-## 1. `start_flask_server.bat`
+## 1. `scripts/start_dev.bat`
 
-**目的**: FlaskベースのWeb GUIアプリケーションを起動します。このスクリプトは、Webインターフェースのみを提供し、スケジューラバックエンドとは独立して動作します。
+**目的**: 開発環境用にタスクスケジューラアプリケーション（FastAPI + WebGUI統合版）を起動します。
 
-**設定**:
-*   `python src/webgui/app.py`: `src/webgui/app.py`にあるFlaskアプリケーションを直接実行します。
-*   **環境変数 `FLASK_PORT`**: Flaskサーバーがリッスンするポートを指定できます。指定しない場合、デフォルトで`5012`が使用されます。
-    例: `set FLASK_PORT=8080 && python src/webgui/app.py`
-
-**使用方法**:
-Web GUIのみを起動し、スケジューラバックエンドは別途起動する場合（または既に起動している場合）に使用します。
-
-## 2. `start_gui_scheduler.bat`
-
-**目的**: FastAPIベースのスケジューラバックエンドとFlaskベースのWeb GUIの両方を同時に起動します。これは、開発時やアプリケーション全体を一度に起動したい場合に便利です。
-
-**設定**:
-*   `start /B uvicorn src.scheduler.main:app --reload --port 8000`: FastAPIスケジューラバックエンドをバックグラウンドで起動します。
-    *   `--reload`: コード変更時に自動的にリロードします。
-    *   `--port 8000`: ポート8000でリッスンします。
-*   `start /B python src/webgui/app.py`: Flask Web GUIをバックグラウンドで起動します。
-    *   **環境変数 `FLASK_PORT`**: Flaskサーバーのポートを指定できます（上記`start_flask_server.bat`と同様）。
+**設定・挙動**:
+* 仮想環境（`.venv\Scripts\activate.bat` または `venv\Scripts\activate.bat`）を自動検知してアクティベートします。
+* `PYTHONPATH` に `src` ディレクトリを追加します。
+* `PYTHONDONTWRITEBYTECODE=1` および `python -B src/main.py` により、`.pyc` ファイルを生成せずにアプリケーションを実行します。
 
 **使用方法**:
-スケジューラとWeb GUIの両方を一度に起動して、フル機能のアプリケーション環境をセットアップする場合に使用します。
+```cmd
+scripts\start_dev.bat
+```
+起動完了後、ブラウザから `http://127.0.0.1:8000` にアクセスして WebGUI を利用できます。
 
-## 3. `start_webgui_only.bat`
+---
 
-**目的**: `start_flask_server.bat`と同様に、FlaskベースのWeb GUIアプリケーションのみを起動します。スクリプトの内容は`start_flask_server.bat`と同一である可能性があります。
+## 2. `scripts/start_debug.bat`
 
-**設定**:
-*   `python src/webgui/app.py`: `src/webgui/app.py`にあるFlaskアプリケーションを直接実行します。
-*   **環境変数 `FLASK_PORT`**: Flaskサーバーがリッスンするポートを指定できます。
+**目的**: デバッグ実行用にタスクスケジューラアプリケーションを起動します。
+
+**設定・挙動**:
+* `start_dev.bat` と同様に仮想環境（`.venv` / `venv`）をアクティベートして実行します。
+* デバッグ時の環境変数 `PYTHONPATH` をクリーンに設定し、FastAPI サーバーを起動します。
 
 **使用方法**:
-`start_flask_server.bat`と同じ目的で使用されます。ファイル名が異なるだけで、機能的には同じである可能性が高いです。
+```cmd
+scripts\start_debug.bat
+```
 
 ---
 
 **補足**:
-*   これらの`.bat`ファイルはWindows環境での使用を想定しています。
-*   `start /B`コマンドは、新しいコマンドプロンプトウィンドウを開かずにバックグラウンドでプロセスを実行します。これにより、複数のコンポーネントを1つのスクリプトから起動できます。
-*   `jobs.yaml`ファイルは、スケジューラが管理するジョブの定義に使用されます。通常、プロジェクトのルートディレクトリに配置されます。
+* これらの `.bat` ファイルは Windows 環境での使用を想定しています。
+* `uv` 環境（`.venv`）および従来の `venv` の両方に対応しています。
+* ジョブ設定はプロジェクトルートの `jobs.yaml` を参照します。

--- a/doc/setup/TSK-OP-001_セットアップガイド.md
+++ b/doc/setup/TSK-OP-001_セットアップガイド.md
@@ -13,57 +13,49 @@ cd task_schedule
 
 ## 2. Create and Activate a Virtual Environment
 
-It is recommended to use a virtual environment to manage dependencies.
+It is recommended to use `uv` (or standard `venv`) to manage dependencies.
 
 ```bash
-# Create a virtual environment
-python -m venv venv
+# Using uv (Recommended)
+uv sync
 
-# Activate the virtual environment
+# Or using standard venv
+python -m venv .venv
 # On Windows
-.\venv\Scripts\activate
+.\.venv\Scripts\activate
 # On macOS/Linux
-# source venv/bin/activate
+# source .venv/bin/activate
 ```
 
 ## 3. Install Dependencies
 
-Install the required Python packages using `pip`. The dependencies are listed in `pyproject.toml`.
+Install the required Python packages using `pip` or `uv`. The dependencies are listed in `pyproject.toml`.
 
-```bash
-pip install -e .
-```
-This command installs the project in editable mode and also installs all the dependencies.
-To install dev dependencies run the following command.
 ```bash
 pip install -e .[dev]
 ```
-
+Or with `uv`:
+```bash
+uv sync --extra dev
+```
 
 ## 4. Run the Application
 
-The application consists of two main components that need to be run separately: the FastAPI scheduler and the Flask-based Web GUI.
-
-Open two separate terminals or command prompts, and activate the virtual environment in both.
-
-### Terminal 1: Start the Web GUI
-
-```bash
-set PYTHONPATH=./src
-python src/webgui/app.py
-```
-
-### Terminal 2: Start the FastAPI Scheduler
+The scheduler backend and Web GUI are integrated into a single FastAPI application.
 
 ```bash
 set PYTHONPATH=./src
 python src/main.py
 ```
+Or with `uv`:
+```bash
+uv run python src/main.py
+```
 
-Alternatively, you can use the provided batch script on Windows to start both processes.
+Alternatively, you can use the provided batch script on Windows:
 
 ```bash
 scripts\start_dev.bat
 ```
 
-Once both components are running, you can access the Web GUI by navigating to `http://127.0.0.1:5000` in your web browser.
+Once running, access the Web GUI by navigating to `http://127.0.0.1:8000` in your web browser.


### PR DESCRIPTION
## 概要
PR #11（WebGUIのFastAPI統合・Flask廃止）に伴い、内容が古くなっていたセットアップガイドおよびプロセス起動スクリプトのドキュメントを最新の構成に更新しました。

## 変更内容
- **`doc/setup/TSK-OP-001_セットアップガイド.md`**
  - Flask版 WebGUI と Scheduler を別々起動する旧手順を削除し、FastAPI統合版（`src/main.py` / ポート 8000）の起動手順に修正
  - `uv` 環境（`uv sync` / `uv run`）および `.venv` の使用手順を追記
- **`doc/how-to/TSK-HT-001_プロセス起動スクリプト説明.md`**
  - 旧 Flask 用 `.bat` ファイルの記述を削除
  - 現行の `scripts/start_dev.bat` および `scripts/start_debug.bat` の挙動・使用方法を解説する内容へ全面改訂

## 関連
- ターゲットブランチ: `main`
- 作業ブランチ: `docs/update-fastapi-setup-guide`
