### PR TITLE
ci: PRマージ時に作業ブランチを自動削除するGitHub Actionsワークフローを追加

### DIFF
--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -1,0 +1,36 @@
+name: Auto Delete Merged Branch
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main, develop]
+
+jobs:
+  delete-merged-branch:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+    steps:
+      - name: Delete Head Branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const headRef = context.payload.pull_request.head.ref;
+            const protectedBranches = ['main', 'master', 'develop'];
+            if (protectedBranches.includes(headRef)) {
+              console.log(`Branch '${headRef}' is protected. Skipping deletion.`);
+              return;
+            }
+            const ref = `heads/${headRef}`;
+            console.log(`Deleting head branch ref: ${ref}`);
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: ref,
+              });
+              console.log(`Successfully deleted branch '${headRef}'.`);
+            } catch (error) {
+              console.log(`Branch deletion skipped or already deleted: ${error.message}`);
+            }


### PR DESCRIPTION
## 概要
PRが `main` や `develop` ブランチにマージされた際、マージ済みの作業ブランチを GitHub リポジトリ上から自動削除する GitHub Actions ワークフローを追加しました。

## 変更内容
- **`.github/workflows/delete-merged-branch.yml`** [NEW]:
  - `pull_request` (`types: [closed]`) トリガーでのマージ判定
  - `actions/github-script` による安全な `git.deleteRef` 実行
  - `main`, `develop` 等の主要ブランチに対するスキップ保護

## 関連
- 作業ブランチ: `ci/auto-delete-merged-branches`
- ターゲットブランチ: `main`
